### PR TITLE
ASTRACTL-19369 Removed error wrapping from API response in GetUserCount()

### DIFF
--- a/client.go
+++ b/client.go
@@ -2352,7 +2352,7 @@ func (client *gocloak) GetUserCount(ctx context.Context, token string, realm str
 		Get(client.getAdminRealmURL(realm, "users", "count"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
-		return -1, errors.Wrap(err, errMessage)
+		return -1, err
 	}
 
 	return result, nil


### PR DESCRIPTION
Remove error wrapping from GetUserCount() API response. This was preventing Astra code from properly detecting 401 unauthorized response and updating the shared token.

Checked the rest of the API call implementations and this is the only one that was wrapping the actual API response, leading me to believe this is an upstream bug and not by design.
