### PR TITLE
remove wrapped error on GetGroupsCount

### DIFF
--- a/client.go
+++ b/client.go
@@ -1579,7 +1579,7 @@ func (client *gocloak) GetGroupsCount(ctx context.Context, token, realm string, 
 		Get(client.getAdminRealmURL(realm, "groups", "count"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
-		return -1, errors.Wrap(err, errMessage)
+		return -1, err
 	}
 
 	return result.Count, nil


### PR DESCRIPTION
Removes the wrapped error on GetGroupsCount in order to do type assertion on it and pull the response code. 
